### PR TITLE
Restore requirements-read-the-docs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,6 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install .
         python -m pip install -r requirements-dev.txt
+        python -m pip install -r requirements-read-the-docs.txt
     - name: Run checks and build docs
       run: .ci/test.sh
     - name: Verify build

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -25,6 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install .
         python -m pip install -r requirements-dev.txt
+        python -m pip install -r requirements-read-the-docs.txt
     - name: Run checks and build docs
       run: |
         .ci/test.sh

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,11 +5,9 @@ flake8
 flake8-docstrings
 flake8-import-order
 isort
-git+https://github.com/crossnox/m2r@dev#egg=m2r  # See https://github.com/sphinx-doc/sphinx/issues/7420
 matplotlib
 pip-tools
 pre-commit
 pytest
 pytest-cov
 responses
-sphinx_autodoc_typehints

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,10 +4,8 @@
 #
 #    pip-compile requirements-dev.in
 #
-alabaster==0.7.12         # via sphinx
 appdirs==1.4.4            # via black, virtualenv
 attrs==19.3.0             # via black, pytest
-babel==2.8.0              # via sphinx
 black==19.10b0            # via -r requirements-dev.in
 certifi==2020.6.20        # via -c requirements.txt, requests
 cfgv==3.1.0               # via pre-commit
@@ -16,27 +14,21 @@ click==7.1.2              # via black, pip-tools
 coverage==5.2.1           # via pytest-cov
 cycler==0.10.0            # via matplotlib
 distlib==0.3.1            # via virtualenv
-docutils==0.15.2          # via -c requirements.txt, m2r, sphinx
 filelock==3.0.12          # via virtualenv
 flake8-docstrings==1.5.0  # via -r requirements-dev.in
 flake8-import-order==0.18.1  # via -r requirements-dev.in
 flake8==3.8.3             # via -r requirements-dev.in, flake8-docstrings
 identify==1.4.25          # via pre-commit
 idna==2.10                # via -c requirements.txt, requests
-imagesize==1.2.0          # via sphinx
 importlib-metadata==1.7.0  # via flake8, pluggy, pre-commit, pytest, virtualenv
 isort==5.2.0              # via -r requirements-dev.in
-jinja2==2.11.2            # via sphinx
 kiwisolver==1.2.0         # via matplotlib
-git+https://github.com/crossnox/m2r@dev#egg=m2r  # via -r requirements-dev.in
-markupsafe==1.1.1         # via jinja2
 matplotlib==3.3.0         # via -r requirements-dev.in
 mccabe==0.6.1             # via flake8
-mistune==0.8.4            # via m2r
 more-itertools==8.4.0     # via pytest
 nodeenv==1.4.0            # via pre-commit
 numpy==1.19.1             # via -c requirements.txt, matplotlib
-packaging==20.4           # via pytest, sphinx
+packaging==20.4           # via pytest
 pathspec==0.8.0           # via black
 pillow==7.2.0             # via -c requirements.txt, matplotlib
 pip-tools==5.3.0          # via -r requirements-dev.in
@@ -46,26 +38,16 @@ py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8, flake8-import-order
 pydocstyle==5.0.2         # via flake8-docstrings
 pyflakes==2.2.0           # via flake8
-pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via matplotlib, packaging
 pytest-cov==2.10.0        # via -r requirements-dev.in
 pytest==5.4.3             # via -r requirements-dev.in, pytest-cov
 python-dateutil==2.8.1    # via -c requirements.txt, matplotlib
-pytz==2020.1              # via -c requirements.txt, babel
 pyyaml==5.3.1             # via pre-commit
 regex==2020.7.14          # via black
-requests==2.24.0          # via -c requirements.txt, responses, sphinx
+requests==2.24.0          # via -c requirements.txt, responses
 responses==0.10.15        # via -r requirements-dev.in
 six==1.15.0               # via -c requirements.txt, cycler, packaging, pip-tools, python-dateutil, responses, virtualenv
-snowballstemmer==2.0.0    # via pydocstyle, sphinx
-sphinx-autodoc-typehints==1.11.0  # via -r requirements-dev.in
-sphinx==3.1.2             # via sphinx-autodoc-typehints
-sphinxcontrib-applehelp==1.0.2  # via sphinx
-sphinxcontrib-devhelp==1.0.2  # via sphinx
-sphinxcontrib-htmlhelp==1.0.3  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.3  # via sphinx
-sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+snowballstemmer==2.0.0    # via pydocstyle
 toml==0.10.1              # via black, pre-commit
 typed-ast==1.4.1          # via black
 urllib3==1.25.10          # via -c requirements.txt, requests

--- a/requirements-read-the-docs.txt
+++ b/requirements-read-the-docs.txt
@@ -1,0 +1,4 @@
+git+https://github.com/crossnox/m2r@dev#egg=m2r  # See https://github.com/sphinx-doc/sphinx/issues/7420
+sphinx_autodoc_typehints
+
+.


### PR DESCRIPTION
# Pull Request Process

Contributors from outside ShopRunner should feel free to submit a PR without having completed all of the items below. See [CONTRIBUTING.md](https://github.com/ShopRunner/wildebeest/blob/master/CONTRIBUTING.md) for additional information.

You can run `./.ci/test.sh` locally to check for style issues, run tests, rebuild docs, etc. before submitting changes.

## Description

I broke our readthedocs build by deleting requirements-read-the-docs.txt and moving those requirements to requirements.in. This PR fixes it.

This is not a change to the library, so IMO the version number shouldn't change.

## Checklist

### General

- [x] Pull request [uses keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to close relevant [issues](https://github.com/ShopRunner/wildebeest/issues).
- [x] Pull request includes unit tests for any bug fixes and new functionality.
- [x] Docs have been updated as needed. (`sphinx-build docs docs/_html` rebuilds the docs. Open `docs/_html/index.html` to check them.)

### ShopRunner Contributors

The maintainer will complete the following steps for contributions from outside ShopRunner.

- [ ] `CHANGELOG.md` has been updated.
- [ ] `_version.py` has been updated.
- [ ] Version number has been updated in `docs/conf.py`.
