### PR TITLE
Update prod GitHub Actions workflow to correctly skip when `_version.py` is not modified

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -51,12 +51,14 @@ jobs:
         pip install setuptools wheel twine
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v2.1
+      uses: jitterbit/get-changed-files@v1
+      with:
+        format: space-delimited
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      if: contains(steps.changed-files.outputs.modified_files, '_version.py')
+      if: contains(steps.changed-files.outputs.modified, '_version.py')
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
# Pull Request Process

Contributors from outside ShopRunner should feel free to submit a PR without having completed all of the items below. See [CONTRIBUTING.md](https://github.com/ShopRunner/wildebeest/blob/master/CONTRIBUTING.md) for additional information.

You can run `./.ci/test.sh` locally to check for style issues, run tests, rebuild docs, etc. before submitting changes.

## Description

With the preceding PR, we got close to the correct skipping behavior, but it looks like the action template I used only works for PR workflows. I've updated it with one that works on `push`. 

<img width="508" alt="Screen Shot 2021-04-02 at 11 09 37 AM" src="https://user-images.githubusercontent.com/31417712/113432991-fa1ba480-93a3-11eb-9081-13c90daacc02.png">

## Checklist

### General

- [ ] Pull request [uses keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to close relevant [issues](https://github.com/ShopRunner/wildebeest/issues).
- [ ] Pull request includes unit tests for any bug fixes and new functionality.
- [ ] Docs have been updated as needed. (`sphinx-build docs docs/_html` rebuilds the docs. Open `docs/_html/index.html` to check them.)

### ShopRunner Contributors

The maintainer will complete the following steps for contributions from outside ShopRunner.

- [ ] `CHANGELOG.md` has been updated.
- [ ] `_version.py` has been updated.
- [ ] Version number has been updated in `docs/conf.py`.